### PR TITLE
Set minimum perl version explicitly

### DIFF
--- a/META.json
+++ b/META.json
@@ -34,7 +34,8 @@
          "requires" : {
             "Minion" : "7",
             "Mojo::mysql" : "1.04",
-            "Mojolicious" : "0"
+            "Mojolicious" : "0",
+            "perl" : "5.010"
          }
       },
       "test" : {

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 
-
+use 5.010;
 
 use ExtUtils::MakeMaker;
 
@@ -14,6 +14,7 @@ my %WriteMakefileArgs = (
   },
   "DISTNAME" => "Minion-Backend-mysql",
   "LICENSE" => "perl",
+  "MIN_PERL_VERSION" => "5.010",
   "NAME" => "Minion::Backend::mysql",
   "PREREQ_PM" => {
     "Minion" => 7,

--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,7 @@
 requires "Minion" => "7";
 requires "Mojo::mysql" => "1.04";
 requires "Mojolicious" => "0";
+requires "perl" => "5.010";
 
 on 'test' => sub {
   requires "ExtUtils::MakeMaker" => "0";

--- a/dist.ini
+++ b/dist.ini
@@ -125,6 +125,7 @@ allow_dirty_match = .*[.]PL
 ; --- Project-specific directives
 
 [Prereqs]
+perl = 5.010
 Mojolicious = 0
 Minion = 7
 Mojo::mysql = 1.04

--- a/lib/Minion/Backend/mysql.pm
+++ b/lib/Minion/Backend/mysql.pm
@@ -1,5 +1,7 @@
 package Minion::Backend::mysql;
 
+use 5.010;
+
 use Mojo::Base 'Minion::Backend';
 
 use Mojo::IOLoop;


### PR DESCRIPTION
This change makes the dist satisfy the
[meta_yml_declares_perl_version](https://cpants.cpanauthors.org/kwalitee/meta_yml_declares_perl_version)
CPANTS requirement.  The minimum version was found via the `perlver`
script of the `Perl::MinimumVersion` module.

This PR is submitted in the hope that it is useful.  If you have any questions or comments, please just let me know.  Also, if you want anything changed, I'm happy to update the PR and resubmit.