### PR TITLE
Add missing prereq used in tests: Time::HiRes

### DIFF
--- a/META.json
+++ b/META.json
@@ -47,7 +47,8 @@
             "IO::Handle" : "0",
             "IPC::Open3" : "0",
             "Test::More" : "0",
-            "Test::mysqld" : "0"
+            "Test::mysqld" : "0",
+            "Time::HiRes" : "0"
          }
       }
    },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,7 +26,8 @@ my %WriteMakefileArgs = (
     "IO::Handle" => 0,
     "IPC::Open3" => 0,
     "Test::More" => 0,
-    "Test::mysqld" => 0
+    "Test::mysqld" => 0,
+    "Time::HiRes" => 0
   },
   "VERSION" => "0.09",
   "test" => {
@@ -44,7 +45,8 @@ my %FallbackPrereqs = (
   "Mojo::mysql" => "1.04",
   "Mojolicious" => 0,
   "Test::More" => 0,
-  "Test::mysqld" => 0
+  "Test::mysqld" => 0,
+  "Time::HiRes" => 0
 );
 
 

--- a/cpanfile
+++ b/cpanfile
@@ -9,6 +9,7 @@ on 'test' => sub {
   requires "IPC::Open3" => "0";
   requires "Test::More" => "0";
   requires "Test::mysqld" => "0";
+  requires "Time::HiRes" => "0";
 };
 
 on 'test' => sub {

--- a/dist.ini
+++ b/dist.ini
@@ -131,3 +131,4 @@ Mojo::mysql = 1.04
 
 [Prereqs / TestRequires]
 Test::mysqld = 0
+Time::HiRes = 0


### PR DESCRIPTION
This addresses the
[build_prereq_matches_use](https://cpants.cpanauthors.org/kwalitee/build_prereq_matches_use)
CPANTS issue.

This PR is submitted in the hope that it is useful. If you have any questions or comments, please just let me know. Also, if you want anything changed, I'm happy to update the PR and resubmit.