### PR TITLE
Replace text substitution with DZ badges plugin

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.org/paultcochrane/Minion-Backend-mysql.svg?branch=master)](https://travis-ci.org/paultcochrane/Minion-Backend-mysql)
+[![Coverage Status](https://coveralls.io/repos/paultcochrane/Minion-Backend-mysql/badge.svg?branch=master)](https://coveralls.io/r/paultcochrane/Minion-Backend-mysql?branch=master)
+
 # NAME
 
 Minion::Backend::mysql
@@ -6,9 +9,6 @@ Minion::Backend::mysql
 
 version 0.09
 
-# STATUS
-
-<a href="https://travis-ci.org/preaction/Minion-Backend-mysql"><img src="https://travis-ci.org/preaction/Minion-Backend-mysql.svg?branch=master"></a><a href="https://coveralls.io/r/preaction/Minion-Backend-mysql"><img src="https://coveralls.io/repos/preaction/Minion-Backend-mysql/badge.png" alt="Coverage Status" /></a>
 
 # SYNOPSIS
 

--- a/dist.ini
+++ b/dist.ini
@@ -73,9 +73,9 @@ copy = LICENSE
 copy = Makefile.PL
 copy = CHANGES
 
-[Run::AfterBuild]
-; Add travis and coveralls badges to README.mkdn
-run = perl -pi -e 's{(# SYNOPSIS)}{# STATUS\n\n<a href="https://travis-ci.org/preaction/Minion-Backend-mysql"><img src="https://travis-ci.org/preaction/Minion-Backend-mysql.svg?branch=master"></a><a href="https://coveralls.io/r/preaction/Minion-Backend-mysql"><img src="https://coveralls.io/repos/preaction/Minion-Backend-mysql/badge.png" alt="Coverage Status" /></a>\n\n$1}' README.mkdn
+[GitHubREADME::Badge]
+badges = travis
+badges = coveralls
 
 ; --- Git management
 [CheckChangesHasContent]


### PR DESCRIPTION
The GitHubREADME::Badge Dist::Zilla plugin does the same job as the
AfterBuild command was doing (although puts the info in a different
location in the README) and is a more configurable way of adding badges
to the README on GitHub.

I stumbled upon this solution while trying to get this dist to build on AppVeyor, which *almost* worked, but since `Test::mysqld` is Unix-only, it wouldn't work in the end.  Nevertheless, hopefully this patch helps a bit.