### PR TITLE
Remove POD lines containing only whitespace

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -13,16 +13,16 @@ version 0.09
 # SYNOPSIS
 
     use Mojolicious::Lite;
-    
+
     plugin Minion => {mysql => 'mysql://user@127.0.0.1/minion_jobs'};
-    
+
     # Slow task
     app->minion->add_task(poke_mojo => sub {
       my $job = shift;
       $job->app->ua->get('mojolicio.us');
       $job->app->log->debug('We have poked mojolicio.us for a visitor');
     });
-    
+
     # Perform job in a background worker process
     get '/' => sub {
       my $c = shift;

--- a/lib/Minion/Backend/mysql.pm
+++ b/lib/Minion/Backend/mysql.pm
@@ -334,16 +334,16 @@ Minion::Backend::mysql - MySQL backend
 =head1 SYNOPSIS
 
   use Mojolicious::Lite;
-  
+
   plugin Minion => {mysql => 'mysql://user@127.0.0.1/minion_jobs'};
-  
+
   # Slow task
   app->minion->add_task(poke_mojo => sub {
     my $job = shift;
     $job->app->ua->get('mojolicio.us');
     $job->app->log->debug('We have poked mojolicio.us for a visitor');
   });
-  
+
   # Perform job in a background worker process
   get '/' => sub {
     my $c = shift;


### PR DESCRIPTION
`podchecker` complains about these lines being present, so it's best to
remove them.