### PR TITLE
Ignore more automatically generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 Minion-Backend-mysql-*
+MYMETA.json
+MYMETA.yml
+Makefile
+blib/
+pm_to_blib

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.build/
 Minion-Backend-mysql-*
 MYMETA.json
 MYMETA.yml


### PR DESCRIPTION
I happened to notice that there's a `Makefile.PL` in this project and thought I'd run it to see if it works (it does).  Nevertheless, it had some leftovers after a make run, which are cleaned up in these commits.  Also, it's possilbe for `dzil` to fail and still leave the `.build/` dir lying around, hence I've also added it to the ignore list.  Hope this helps!  If not, don't worry about it and just close as unmerged :-)