### PR TITLE
Fix use of uninitialized value warning.

### DIFF
--- a/lib/Minion/Backend/mysql.pm
+++ b/lib/Minion/Backend/mysql.pm
@@ -55,7 +55,7 @@ SQL
   my $current_hour = $now->hour;
   for my $i ( 0..23 ) {
     my $i_hour = ( $current_hour - ( 23 - $i ) ) % 24;
-    if ( $data->[ $i ]{ hour } != $i_hour ) {
+    if ( exists $data->[$i] and $data->[ $i ]{ hour } != $i_hour ) {
       my $epoch = $now->epoch - ( 3600 * ( 24 - $i ) );
       splice @$data, $i, 0, {
         epoch => $epoch - ( $epoch % 3600 ),


### PR DESCRIPTION
When trying to assemble the history for use in the Minion admin
dashboard, the MySQL backend produces the following warning:

Use of uninitialized value in numeric ne (!=) at
.../Minion/Backend/mysql.pm line 58.

This patch ensures that the warning never occurs by ensuring there is
data available for comparison before attempting to make a comparison.